### PR TITLE
Moving protocol.json file to /json/protocol/ per issue #20

### DIFF
--- a/EdgeDiagnosticsAdapter/WebSocketHandler.cpp
+++ b/EdgeDiagnosticsAdapter/WebSocketHandler.cpp
@@ -76,7 +76,7 @@ void WebSocketHandler::OnHttp(websocketpp::connection_hdl hdl)
 			ss << page;
 		}
 	}
-	else if (requestedResource == "/protocol.json")
+	else if (requestedResource == "/json/protocol")
 	{
 		// Load and return the protocol.json file
 		CString protocolJsonFile;


### PR DESCRIPTION
Fix for issue #20.

This change serves the protocol.json from /json/protocol i.e. http://localhost:9222/json/protocol the URL is case sensitive and should be all lower case. 
