### PR TITLE
Fix issue19

### DIFF
--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -445,7 +445,8 @@ namespace Helpers
 		UINT32 packageNamesBufferLength = 0;
 		result = FindPackagesByPackageFamily(edgeFamilyName, PACKAGE_FILTER_HEAD | PACKAGE_INFORMATION_BASIC, &packageCount, nullptr, &packageNamesBufferLength, nullptr, nullptr);
 
-		if (result != ERROR_SUCCESS)
+		// The first time we call the API we are getting the length of the buffer which some times returns an error (?!)
+		if (result != ERROR_SUCCESS && result != ERROR_INSUFFICIENT_BUFFER)
 		{
 			return E_FAIL;
 		}

--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -445,7 +445,7 @@ namespace Helpers
 		UINT32 packageNamesBufferLength = 0;
 		result = FindPackagesByPackageFamily(edgeFamilyName, PACKAGE_FILTER_HEAD | PACKAGE_INFORMATION_BASIC, &packageCount, nullptr, &packageNamesBufferLength, nullptr, nullptr);
 
-		// The first time we call the API we are getting the length of the buffer which some times returns an error (?!)
+		// The first time we call the API we are getting the length of the buffer which also returns the error ERROR_INSUFFICIENT_BUFFER
 		if (result != ERROR_SUCCESS && result != ERROR_INSUFFICIENT_BUFFER)
 		{
 			return E_FAIL;


### PR DESCRIPTION
This change moves to lookup the SID for "All App Packages" by resolving it's sid string as the name itself is localized. It also updates the PLM disable logic to be correctly allow for an insufficient buffer error.