### PR TITLE
Upgrading typings to 1.0.4 and Fix #33

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ var sources = [
     'src',
     'lib',
     'test',
-    'typings/main'
+    'typings'
 ].map(function(tsFolder) { return tsFolder + '/**/*.ts'; });
 
 var lintSources = [
@@ -48,10 +48,10 @@ var projectConfig = {
 };
 
 gulp.task('buildtypescript', function () {
-	return gulp.src(sources, { base: '.' }) 
-        .pipe(sourcemaps.init()) 
-        .pipe(ts(projectConfig)).js 
-        .pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: 'file:///' + __dirname })) 
+	return gulp.src(sources, { base: '.' })
+        .pipe(sourcemaps.init())
+        .pipe(ts(projectConfig)).js
+        .pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: 'file:///' + __dirname }))
         .pipe(gulp.dest('out'));
 });
 
@@ -68,7 +68,7 @@ function getNativeBuildOptions() {
     const verbose = (argv.verbose ? '' : 'ErrorsOnly;WarningsOnly')
     const outDir = 'out/native/' + config + '/' + arch + '/';
     const outArch =  (argv.x64 ? '64' : '');
-    
+
     return {
         target: target,
         config: config,
@@ -98,7 +98,7 @@ gulp.task('buildnativeaddon', ['buildnativeprojects'], function(done) {
     const opts = getNativeBuildOptions();
     const arch = opts.arch == "Win32" ? "ia32" : "x64";
     const gypPath = __dirname + "/node_modules/.bin/node-gyp";
-    
+
     return exec('cd native/Addon && ' + gypPath + ' clean configure build --arch=' + arch + " --module_arch=" + opts.outArch, function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
@@ -108,7 +108,10 @@ gulp.task('buildnativeaddon', ['buildnativeprojects'], function(done) {
 
 gulp.task('buildnative', ['buildnativeaddon'], function() {
     const opts = getNativeBuildOptions();
-    return gulp.src([opts.outDir + 'Proxy' + opts.outArch + '.dll'], { base: opts.outDir })
+    return gulp.src([
+                opts.outDir + 'Proxy' + opts.outArch + '.dll',
+                opts.outDir + 'Proxy' + opts.outArch + '.pdb'
+            ], { base: opts.outDir })
             .pipe(gulp.dest('out/lib'));
 });
 
@@ -123,11 +126,11 @@ gulp.task('watch', ['buildscript'], function() {
     return gulp.watch(sources, ['buildscript']);
 });
 
-gulp.task('tslint', function() { 
+gulp.task('tslint', function() {
     return gulp.src(lintSources, { base: '.' })
-         .pipe(tslint()) 
-         .pipe(tslint.report('verbose')); 
-}); 
+         .pipe(tslint())
+         .pipe(tslint.report('verbose'));
+});
 
 function test() {
     return gulp.src('out/test/**/*.test.js', { read: false })

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     ],
     "author": "Microsoft Corporation",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/edge-diagnostics-adapter.git"
+    },
     "dependencies": {
         "ws": "1.1.0"
     },
@@ -26,7 +30,7 @@
         "node-gyp": "^3.3.1",
         "tslint": "^3.3.0",
         "typescript": "1.8.7",
-        "typings": "0.8.1",
+        "typings": "1.0.4",
         "yargs": "^4.6.0"
     }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-    "ambientDependencies": {
+    "globalDependencies": {
         "node": "registry:dt/node#4.0.0+20160423143914",
         "ws": "registry:dt/ws#0.0.0+20160317120654",
         "yargs": "registry:dt/yargs#0.0.0+20160326124407"


### PR DESCRIPTION
Gulp build now drops the pdb in the lib folder for nice stacktraces in windbg
EdgeAdapterService binds port on 0.0.0.0 so it can be accessed from a different machine.
Fixed variable names