### PR TITLE
Solves compilation error AsyncProgressWorker not defined

### DIFF
--- a/native/Addon/MessageReceiver.h
+++ b/native/Addon/MessageReceiver.h
@@ -37,7 +37,7 @@ private:
     HWND m_proxyHwnd;
     HWND* m_pReceiverHwnd;
     Nan::Callback* m_pProgressCallback;
-    const AsyncProgressWorker::ExecutionProgress* m_pExecutionProgress;
+    const Nan::AsyncProgressWorker::ExecutionProgress* m_pExecutionProgress;
     vector<MessageInfo> m_messages;
     uv_mutex_t m_lock;
 };


### PR DESCRIPTION
When using gulp build to build the native asset the message "error C2653: 'AsyncProgressWorker': is not a class or namespace name (compiling source file ..\MessageReceiver.cpp)" appeared.

This PR just adds the namespace name before the class to solve the compilation error.