### PR TITLE
Update vscode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,9 @@
             "name": "Launch Server",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceRoot}/out/src/adapterService/edgeAdapter.js",
+            "program": "${workspaceRoot}/src/edgeAdapter.ts",
             "stopOnEntry": false,
-            "args": [],
+            "args": ["--servetools", "--diagnostics"],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": null,
             "runtimeExecutable": null,
@@ -17,10 +17,11 @@
             "env": {
                 "NODE_ENV": "development"
             },
-            "externalConsole": false,
+            "console": "integratedTerminal",
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out"
-        },
+            "trace": "all",
+            "outFiles": ["${workspaceRoot}/out/src/**/*.js"]
+        },   
         {
             "name": "Debug Gulp",
             "type": "node",
@@ -40,6 +41,6 @@
             "externalConsole": false,
             "sourceMaps": true,
             "outDir": "${workspaceRoot}/out"
-        },
+        }
     ]
 }

--- a/src/adapterService/edgeAdapterService.ts
+++ b/src/adapterService/edgeAdapterService.ts
@@ -25,7 +25,7 @@
     }
 })();
 
-import {IChromeInstance} from '../../lib/EdgeAdapterInterfaces.d.ts'
+import {IChromeInstance} from '../../lib/EdgeAdapterInterfaces'
 import * as edgeAdapter from '../../lib/Addon.node';
 import * as http from 'http';
 import * as ws from 'ws';

--- a/src/edgeAdapter.ts
+++ b/src/edgeAdapter.ts
@@ -3,7 +3,7 @@
 //
 
 import {argv} from 'yargs';
-import {EdgeAdapter} from './adapterService/EdgeAdapterService';
+import {EdgeAdapter} from './adapterService/edgeAdapterService';
 
 if (argv.h || argv.help || argv["?"]) {
     console.log("node edgeAdapter.js <options>");


### PR DESCRIPTION
Including module name using same casing as filename. This solves the issue that vscode were not able to find the breakpoints.