### PR TITLE
Eda deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > **Notice of deprecation**<br />
-> This repository has been deprecated. A native replacement for IDE integration with the EdgeHTML platform for debugging and other diagnostics tasks was developed by the Edge team and released in the Windows 10 April 2018 update. To learn more, read about the [Microsoft Edge DevTools Protocol](https://docs.microsoft.com/en-us/microsoft-edge/devtools-protocol/).
+> This repository has been deprecated. A native replacement for VS Code debugging of the EdgeHTML platform is under development by the Edge DevTools team. While an exact ship date is unknown, this functionality is expected to ship in Windows 10 in the first half of 2018.
 
 # Edge Diagnostics Adapter
 [![build status](https://travis-ci.org/Microsoft/edge-diagnostics-adapter.svg?branch=master)](https://travis-ci.org/Microsoft/edge-diagnostics-adapter)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > **Notice of deprecation**
-> This repository has been deprecated. A native replacement for VS Code debugging of the EdgeHTML platform is under development by the Edge DevTools team. While no exact date can be provided, this functionality is expected to ship in Windows 10 in the first half of 2018.
+> This repository has been deprecated. A native replacement for VS Code debugging of the EdgeHTML platform is under development by the Edge DevTools team. While an exact ship date is unknown, this functionality is expected to ship in Windows 10 in the first half of 2018.
 
 # Edge Diagnostics Adapter
 [![build status](https://travis-ci.org/Microsoft/edge-diagnostics-adapter.svg?branch=master)](https://travis-ci.org/Microsoft/edge-diagnostics-adapter)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Notice of deprecation**
+> **Notice of deprecation**<br />
 > This repository has been deprecated. A native replacement for VS Code debugging of the EdgeHTML platform is under development by the Edge DevTools team. While an exact ship date is unknown, this functionality is expected to ship in Windows 10 in the first half of 2018.
 
 # Edge Diagnostics Adapter

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Notice of deprecation**
+> This repository has been deprecated. A native replacement for VS Code debugging of the EdgeHTML platform is under development by the Edge DevTools team. While no exact date can be provided, this functionality is expected to ship in Windows 10 in the first half of 2018.
+
 # Edge Diagnostics Adapter
 [![build status](https://travis-ci.org/Microsoft/edge-diagnostics-adapter.svg?branch=master)](https://travis-ci.org/Microsoft/edge-diagnostics-adapter)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > **Notice of deprecation**<br />
-> This repository has been deprecated. A native replacement for VS Code debugging of the EdgeHTML platform is under development by the Edge DevTools team. While an exact ship date is unknown, this functionality is expected to ship in Windows 10 in the first half of 2018.
+> This repository has been deprecated. A native replacement for IDE integration with the EdgeHTML platform for debugging and other diagnostics tasks was developed by the Edge team and released in the Windows 10 April 2018 update. To learn more, read about the [Microsoft Edge DevTools Protocol](https://docs.microsoft.com/en-us/microsoft-edge/devtools-protocol/).
 
 # Edge Diagnostics Adapter
 [![build status](https://travis-ci.org/Microsoft/edge-diagnostics-adapter.svg?branch=master)](https://travis-ci.org/Microsoft/edge-diagnostics-adapter)


### PR DESCRIPTION
Adding a note about deprecating the repo. We'll also archive it.

Separately, once this is posted, we'll deprecate the NPM package and update the Edge Dev blog post about EDA to note that it's deprecated.

@auchenberg @jacobrossi @molant 